### PR TITLE
fix: handle duplicate CIDR blocks in contains function

### DIFF
--- a/src/contains.ts
+++ b/src/contains.ts
@@ -9,10 +9,15 @@ export function contains(a: string[], b: string[]) {
     bParsedMap[i] = parse(b[i]);
   }
 
-  let numFound = 0;
+  const foundIndices = new Set<number>();
   for (const a1 of a) {
     const aParsed = parse(a1);
     for (let j = 0; j < b_len; j++) {
+      // Skip if this IP from b was already found
+      if (foundIndices.has(j)) {
+        continue;
+      }
+
       const bParsed = bParsedMap[j];
 
       // version mismatch
@@ -34,9 +39,9 @@ export function contains(a: string[], b: string[]) {
         continue; // not contained
       }
 
-      numFound++;
+      foundIndices.add(j);
     }
   }
 
-  return numFound === b_len;
+  return foundIndices.size === b_len;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -147,5 +147,13 @@ describe('cidr-tools-wasm', () => {
 
     expect(contains(['127.0.0.0/8', '223.252.196.0/24'], ['223.252.196.38'])).toBe(true);
     expect(contains(['127.0.0.0/8', '223.252.196.0/24'], ['223.252.196.38/32'])).toBe(true);
+
+    // Test cases for duplicate CIDR blocks
+    expect(contains(['192.168.1.0/24', '192.168.1.0/24'], ['192.168.1.0'])).toBe(true);
+    expect(contains(['192.168.1.0/24', '192.168.1.0/24'], ['192.168.1.255'])).toBe(true);
+    expect(contains(['192.168.1.0/24', '192.168.1.0/24'], ['192.168.2.0'])).toBe(false);
+    expect(contains(['192.168.1.0/24', '192.168.1.0/24', '10.0.0.0/8'], ['192.168.1.5', '10.0.0.1'])).toBe(true);
+    expect(contains(['::/64', '::/64'], ['::1'])).toBe(true);
+    expect(contains(['::/64', '::/64'], ['::/128'])).toBe(true);
   });
 });


### PR DESCRIPTION
Hello - thank you for your work on this wonderful module. I just started using it and noticed that sometimes `contains()` would return `false` for IPs that were definitely within the CIDR blocks passed in. Turns out my source data had duplicate CIDR blocks, which would make `contains()` return `false` (because it would match the IP more than once). This seems like a bug to me, so I have created this PR to fix it.